### PR TITLE
Configure package builds for pip and uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,19 @@ It includes:
 
 Anyway, don't use Papote. It's not meant to be used in production. I'm just
 building skill and understanding. Use HuggingFace.
+
+## Installation
+
+Papote can be installed from source using standard Python packaging tools.
+
+Using `pip`:
+
+```bash
+pip install .
+```
+
+Using [`uv`](https://github.com/astral-sh/uv):
+
+```bash
+uv pip install .
+```

--- a/model_specs/__init__.py
+++ b/model_specs/__init__.py
@@ -1,0 +1,1 @@
+"""Model specification examples for Papote."""

--- a/papote/__init__.py
+++ b/papote/__init__.py
@@ -1,0 +1,1 @@
+"""Papote package."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,5 +17,8 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["papote*", "model_specs*"]


### PR DESCRIPTION
## Summary
- add `__init__.py` modules to expose `papote` and `model_specs`
- configure setuptools package discovery in `pyproject.toml`
- document pip and uv installation in the README

## Testing
- `python -m build`
- `python -m papote.test_all` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_689b8b641aa48332a79a777e1e7acacb