### PR TITLE
Simplify BPE.load signature

### DIFF
--- a/papote/bpe.py
+++ b/papote/bpe.py
@@ -14,7 +14,7 @@ class BPE:
         return self.tokenizer.get_vocab()
 
     @staticmethod
-    def load(directory, writeable=False):
+    def load(directory):
         self = BPE()
         self.tokenizer = Tokenizer.from_file(directory)
         return self

--- a/papote/train_bpe.py
+++ b/papote/train_bpe.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     test = "<|SOH|>La cible effectue un jet de sauvegarde de Sagesse puis tombe inconsciente. Elle est également immunisée aux dégâts de foudre pour 1 tour.<|EOT|><|NUL|>"
 
     if os.path.exists(args.path):
-        bpe = BPE.load(args.path, writeable=True)
+        bpe = BPE.load(args.path)
     else:
         bpe = BPE()
         bpe.learn(


### PR DESCRIPTION
## Summary
- remove unused `writeable` parameter from `BPE.load`
- update `train_bpe` script to match new signature

## Testing
- `python -m papote.test_all` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_689b96f32424833297479f3d64a99896