### PR TITLE
Handle prompt display via explicit None token

### DIFF
--- a/papote/interactive.py
+++ b/papote/interactive.py
@@ -27,18 +27,22 @@ class Printer:
         self.print_prompt = print_prompt
 
     def __call__(self, prompt, next_token, prob, logit):
-        if not next_token:
+        if next_token is None:
             if self.print_prompt:
-                print(self.bpe.decode_text(prompt, self.separator.encode()),
-                      end=self.separator,
-                      flush=True)
+                print(
+                    self.bpe.decode_text(prompt, self.separator.encode()),
+                    end=self.separator,
+                    flush=True,
+                )
         else:
             color = self.colors[int(min(prob, 0.99) * len(self.colors))]
-            print(fg(color) +
-                  self.bpe.vocab[next_token].decode('utf-8', 'ignore') +
-                  attr('reset'),
-                  end=self.separator,
-                  flush=True)
+            print(
+                fg(color)
+                + self.bpe.vocab[next_token].decode("utf-8", "ignore")
+                + attr("reset"),
+                end=self.separator,
+                flush=True,
+            )
 
 
 class Options(OptionsBase):

--- a/papote/sampler.py
+++ b/papote/sampler.py
@@ -184,15 +184,17 @@ class Sampler:
         prompt = NFKC()(prompt)
         encoded = bpe.encode_text(prompt)
         with suppress(KeyboardInterrupt):
+            self.event_handler(encoded, None, None, None)
             while not self.stopping_criterion(encoded):
                 encoded = self.prompt_processor(encoded)
 
                 prompt = torch.tensor(encoded[-self.ctx_len:],
                                       dtype=torch.long)
 
-                logits = F.log_softmax(model((prompt[None]).to(rank),
-                                             kv_cache)[0][-1].float().cpu(),
-                                       dim=-1)
+                logits = F.log_softmax(
+                    model((prompt[None]).to(rank), kv_cache)[0][-1].float().cpu(),
+                    dim=-1,
+                )
                 idx = torch.arange(logits.shape[-1])
 
                 logits, idx = self.logits_policy(logits, idx, prompt)
@@ -200,8 +202,7 @@ class Sampler:
                 probs = F.softmax(logits, dim=-1)
                 next_idx = torch.multinomial(probs, 1).item()
                 next_token = idx[next_idx]
-                self.event_handler(encoded, next_token, probs[next_idx],
-                                   logits[next_idx])
+                self.event_handler(encoded, next_token, probs[next_idx], logits[next_idx])
                 encoded.append(next_token)
             return bpe.decode_text(encoded)
 

--- a/papote/server.py
+++ b/papote/server.py
@@ -37,17 +37,21 @@ class Printer:
         self.num_sent = 0
 
     def __call__(self, prompt, next_token, prob, logit):
-        if self.num_sent == 0:
+        if next_token is None:
             if self.print_prompt:
                 self.send(
-                    '<b>' +
-                    self.bpe.decode_text(prompt, self.separator.encode()) +
-                    '</b>')
+                    '<b>'
+                    + self.bpe.decode_text(prompt, self.separator.encode())
+                    + '</b>'
+                )
             self.num_sent += len(prompt)
+            return
         color = self.colors[int(min(prob, 0.99) * len(self.colors))]
-        self.send('<span style="color: ' + color + '">' +
-                  self.bpe.vocab[next_token].decode('utf-8', 'ignore') +
-                  '</span>')
+        self.send(
+            '<span style="color: ' + color + '">' +
+            self.bpe.vocab[next_token].decode('utf-8', 'ignore') +
+            '</span>'
+        )
         socketio.sleep(0.01)
         self.num_sent += 1
 


### PR DESCRIPTION
## Summary
- Adjust `Printer` to treat `next_token=None` as a signal to output only the prompt
- Call sampler event handler with `None` before generation
- Update server-side printer to accept `None`

## Testing
- `python -m papote.test_all` *(fails: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(proxy error: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689b9c14b15883329cde645f9b71ad92