### PR TITLE
Fix history command in chat

### DIFF
--- a/papote/chat.py
+++ b/papote/chat.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
                     sys.exit(0)
                 elif text == '!reset':
                     history = ''
-                elif command == '!history':
+                elif text == '!history':
                     print('\n````')
                     print(history)
                     print('````\n')


### PR DESCRIPTION
## Summary
- check for the !history command using the actual user text

## Testing
- `python -m papote.test_all` *(fails: No module named 'torch')*
- `python - <<'PY'
history = 'user> hello\n'
text = '!history'
if text.startswith('!'):
    if text == '!history':
        print('\n````')
        print(history)
        print('````\n')
PY`

------
https://chatgpt.com/codex/tasks/task_e_689b9c0fec0c8332aa957e7044635af2