### PR TITLE
Fix Typical sampler p handling and add unit test

### DIFF
--- a/papote/sampler.py
+++ b/papote/sampler.py
@@ -99,7 +99,7 @@ class Typical:
         typical_probs = F.softmax(logits[idx], dim=-1).cumsum(dim=-1)
 
         typical_probs[0] = 0
-        typical_sorted = typical_sorted[typical_probs < typical_p]
+        typical_sorted = typical_sorted[typical_probs < self.p]
         logits = logits[typical_sorted]
         return logits, idx[typical_sorted]
 

--- a/papote/test_all.py
+++ b/papote/test_all.py
@@ -5,6 +5,8 @@ can be trained and used for a simple round-trip encode/decode cycle.
 """
 
 from papote.bpe import BPE
+from papote.sampler import Typical
+import torch
 
 
 def test_roundtrip() -> None:
@@ -17,6 +19,13 @@ def test_roundtrip() -> None:
     ids = bpe.encode_text("hello world")
     decoded = bpe.decode_text(ids)
     assert decoded == "hello world"
+
+
+def test_typical_filters_tokens() -> None:
+    logits = torch.tensor([0.0, 1.0, 2.0, 3.0])
+    idx = torch.arange(logits.size(0))
+    filtered_logits, _ = Typical(0.5)(logits, idx, torch.tensor([]))
+    assert len(filtered_logits) < len(logits)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation


### PR DESCRIPTION
## Summary
- replace undefined `typical_p` with `self.p` in `Typical` sampler
- add unit test ensuring `Typical` filters logits when `p` is provided

## Testing
- `python -m papote.test_all` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_689b9bda8a0083328bf37e32aeb4e64a