### PR TITLE
Ensure unique special tokens in BPE trainer

### DIFF
--- a/papote/bpe.py
+++ b/papote/bpe.py
@@ -66,8 +66,9 @@ class BPE:
             "<|BEL|>",
             "<|BS|>",
             "<|HT|>",
-            "<|EOT|>",
         ]
+        if len(default_specials) != len(set(default_specials)):
+            raise ValueError("Default special tokens must be unique")
         print(f"Training on {len(files)} files.")
         self.tokenizer.train(
             files=files,


### PR DESCRIPTION
## Summary
- remove duplicate `<|EOT|>` entry from default special tokens
- verify special token list is unique before training

## Testing
- `python -m papote.test_all`

------
https://chatgpt.com/codex/tasks/task_e_689b9bc972508332b51e58f2e4546daf