### PR TITLE
Add extensive pytest suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "flask",
     "flask-socketio",
     "colored",
+    "pytest",
 ]
 
 [build-system]
@@ -24,3 +25,6 @@ build-backend = "setuptools.build_meta"
 include = ["papote*", "model_specs*"]
 [tool.uv.sources]
 torchelie = { git = "https://github.com/Vermeille/Torchelie.git", rev = "43028e17ab50fb40c21010a52f523c0fcc532d7d" }
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ ftfy
 flask
 flask-socketio
 colored
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1,0 +1,98 @@
+import os
+import random
+import tempfile
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from papote.data_utils import (
+    RandomCase,
+    RandomPromptSplit,
+    Tokenize,
+    Crop,
+    NFKC,
+    Pad,
+    Align,
+    Tagger,
+    NextTokenObjective,
+    SeqWeightedLoss,
+    binary_entropy,
+)
+
+
+class DummyBPE:
+    def encode_text(self, text):
+        return [ord(c) for c in text]
+
+
+def test_random_case():
+    rc_lower = RandomCase("L_", "U_", lowercase_p=1.0, uppercase_p=0.0)
+    assert rc_lower("Hi") == "L_hi"
+    rc_upper = RandomCase("L_", "U_", lowercase_p=0.0, uppercase_p=1.0)
+    assert rc_upper("Hi") == "U_HI"
+    rc_none = RandomCase("L_", "U_", lowercase_p=0.0, uppercase_p=0.0)
+    assert rc_none("Hi") == "Hi"
+
+
+def test_random_prompt_split():
+    rps = RandomPromptSplit("<S>", p=1.0)
+    random.seed(0)
+    result = rps("hello")
+    assert "<S>" in result and len(result) > len("hello")
+
+
+def test_tokenize_and_crop():
+    tok = Tokenize(DummyBPE())
+    result = tok("hi")
+    expected = [ord(c) for c in "hi<|EOT|>"]
+    assert result == expected
+    crop = Crop(3)
+    assert crop([1, 2, 3, 4]) == [1, 2, 3]
+
+
+def test_nfkc_pad_align():
+    nfkc = NFKC()
+    assert nfkc("ｔｅｓｔ") == "test"
+    pad = Pad(5, 0)
+    assert pad([1, 2]) == [1, 2, 0, 0, 0]
+    align = Align(4, 0)
+    assert align([1, 2, 3, 4, 5]) == [1, 2, 3, 4, 5, 0, 0, 0]
+
+
+def test_tagger():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tag_file = os.path.join(tmpdir, "tags.txt")
+        with open(tag_file, "w") as f:
+            f.write("dir/subdir tag1 tag2\n")
+            f.write("dir tag3\n")
+        tagger = Tagger(tag_file)
+        random.seed(0)
+        tags = tagger.tag_path("dir/subdir/file")
+        assert tags == "tag3tag1tag2<|NUL|>"
+        assert tagger.tags() == {"tag1", "tag2", "tag3"}
+
+
+def test_next_token_objective():
+    obj = NextTokenObjective()
+    data_list = [1, 2, 3]
+    x, y = obj(data_list)
+    assert x == [1, 2]
+    assert y == [2, 3]
+    tensor = torch.tensor([1, 2, 3])
+    x_t, y_t = obj(tensor)
+    assert torch.equal(x_t, torch.tensor([1, 2]))
+    assert torch.equal(y_t, torch.tensor([2, 3]))
+
+
+def test_seq_weighted_loss_and_binary_entropy():
+    loss_fn = SeqWeightedLoss()
+    x = torch.randn(3, 5)
+    y = torch.tensor([1, 2, 3])
+    mask = torch.ones(3)
+    loss = loss_fn(x, y, mask)
+    assert loss.shape == (3,)
+    logits = torch.zeros(2, 2)
+    labels = torch.tensor([0, 1])
+    be = binary_entropy(logits, labels, 'none')
+    expected = torch.full((2,), 2 * torch.log(torch.tensor(2.0)))
+    assert torch.allclose(be, expected)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,21 @@
+import math
+
+from papote.metrics import get_dice_rolls, perplexity
+
+
+class DummyEntropy:
+    def __init__(self, value: float) -> None:
+        self.value = value
+
+    def exp(self) -> float:
+        return math.exp(self.value)
+
+
+def test_get_dice_rolls():
+    text = "10 (1d6) 5 (2d8+1)"
+    assert get_dice_rolls(text) == ["", "+1"]
+
+
+def test_perplexity():
+    ce = DummyEntropy(2.0)
+    assert math.isclose(perplexity(ce), math.exp(2.0))

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,0 +1,110 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from papote.sampler import (
+    ForbiddenTokens,
+    CumulativeRepetitionPenalty,
+    FixedRepetitionPenalty,
+    Temperature,
+    TopK,
+    TopP,
+    Typical,
+    StopTooLong,
+    StopOnEos,
+    candidates_for_continuation,
+    tokenize_continuation,
+)
+
+
+def test_forbidden_tokens():
+    logits = torch.zeros(5)
+    idx = torch.arange(5)
+    ft = ForbiddenTokens([1, 3])
+    new_logits, new_idx = ft(logits.clone(), idx.clone(), torch.tensor([0]))
+    assert torch.isneginf(new_logits[1])
+    assert torch.isneginf(new_logits[3])
+    assert torch.equal(new_idx, idx)
+
+
+def test_cumulative_repetition_penalty():
+    logits = torch.ones(5)
+    idx = torch.arange(5)
+    prompt = torch.tensor([1, 2, 1, 3])
+    crp = CumulativeRepetitionPenalty(penalty=0.5, window=4)
+    new_logits, _ = crp(logits.clone(), idx, prompt)
+    assert torch.isclose(new_logits[1], torch.tensor(0.25))
+    assert torch.isclose(new_logits[2], torch.tensor(0.5))
+    assert torch.isclose(new_logits[4], torch.tensor(1.0))
+
+
+def test_fixed_repetition_penalty():
+    logits = torch.tensor([1.0, 2.0, 3.0, 4.0])
+    idx = torch.arange(4)
+    prompt = torch.tensor([0, 1, 0, 2])
+    frp = FixedRepetitionPenalty(penalty=0.5, window=4)
+    new_logits, _ = frp(logits.clone(), idx, prompt)
+    expected = torch.tensor([0.0, 0.5, 1.0, 3.0])
+    assert torch.allclose(new_logits, expected)
+
+
+def test_temperature():
+    logits = torch.tensor([2.0, 4.0])
+    idx = torch.arange(2)
+    temp = Temperature(2.0)
+    new_logits, _ = temp(logits, idx, torch.tensor([]))
+    assert torch.allclose(new_logits, logits / 2)
+
+
+def test_topk():
+    logits = torch.tensor([1.0, 3.0, 2.0])
+    idx = torch.tensor([0, 1, 2])
+    topk = TopK(k=2)
+    new_logits, new_idx = topk(logits, idx, torch.tensor([]))
+    assert torch.equal(new_idx, torch.tensor([1, 2]))
+    assert torch.equal(new_logits, torch.tensor([3.0, 2.0]))
+
+
+def test_topp():
+    logits = torch.tensor([1.0, 2.0, 3.0])
+    idx = torch.tensor([0, 1, 2])
+    topp = TopP(p=0.5)
+    new_logits, new_idx = topp(logits, idx, torch.tensor([]))
+    assert len(new_logits) == 2
+    assert set(new_idx.tolist()) == {0, 1}
+
+
+def test_typical():
+    logits = torch.tensor([1.0, 2.0, 3.0])
+    idx = torch.tensor([0, 1, 2])
+    typ_none = Typical(None)
+    l_none, i_none = typ_none(logits, idx, torch.tensor([]))
+    assert torch.equal(l_none, logits)
+    assert torch.equal(i_none, idx)
+    typ = Typical(0.5)
+    l, i = typ(logits, idx, torch.tensor([]))
+    assert len(l) <= len(logits)
+    assert len(i) == len(l)
+
+
+def test_stop_criteria():
+    too_long = StopTooLong(max_length=3)
+    assert not too_long([1, 2])
+    assert too_long([1, 2, 3])
+    on_eos = StopOnEos(eos=2)
+    assert on_eos([1, 2])
+    assert not on_eos([1, 3])
+
+
+def test_candidates_for_continuation():
+    vocab = [b"a", b"ab", b"b"]
+    cands = candidates_for_continuation(vocab, b"a")
+    assert cands == [1, 0]
+
+
+def test_tokenize_continuation():
+    vocab = [b"a", b"b", b"c", b"ab"]
+    tokens, cands, cont = tokenize_continuation(vocab, b"abc")
+    assert tokens == [3, 2]
+    assert cont == b""
+    assert cands[0] == 3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,34 @@
+import pytest
+from typing import Optional
+
+from papote.utils import OptionsBase, txt_extensions
+
+
+class MyOptions(OptionsBase):
+    a: int = 1
+    b: Optional[int] = None
+
+
+def test_options_base_parse_sets_attribute():
+    opts = MyOptions()
+    opts.parse("a 5")
+    assert opts.a == 5
+
+
+def test_options_base_parse_union_none():
+    opts = MyOptions()
+    opts.parse("b 7")
+    assert opts.b == 7
+    opts.parse("b")
+    assert opts.b is None
+
+
+def test_options_base_parse_unknown_option():
+    opts = MyOptions()
+    with pytest.raises(ValueError):
+        opts.parse("c 3")
+
+
+def test_txt_extensions_contains_common():
+    assert ".txt" in txt_extensions
+    assert ".md" in txt_extensions

--- a/uv.lock
+++ b/uv.lock
@@ -129,6 +129,18 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -238,6 +250,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
 ]
 
 [[package]]
@@ -647,6 +668,7 @@ dependencies = [
     { name = "flask" },
     { name = "flask-socketio" },
     { name = "ftfy" },
+    { name = "pytest" },
     { name = "tokenizers" },
     { name = "torch" },
     { name = "torchelie" },
@@ -660,6 +682,7 @@ requires-dist = [
     { name = "flask" },
     { name = "flask-socketio" },
     { name = "ftfy" },
+    { name = "pytest" },
     { name = "tokenizers" },
     { name = "torch" },
     { name = "torchelie", git = "https://github.com/Vermeille/Torchelie.git?rev=43028e17ab50fb40c21010a52f523c0fcc532d7d" },
@@ -767,6 +790,42 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/31/5e/03966aedfbfcbb4d5f8aa042452d3361f325b963ebbadddac05b122e47dd/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361", size = 4957170, upload-time = "2025-07-01T09:16:23.762Z" },
     { url = "https://files.pythonhosted.org/packages/cc/2d/e082982aacc927fc2cab48e1e731bdb1643a1406acace8bed0900a61464e/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7", size = 5581505, upload-time = "2025-07-01T09:16:25.593Z" },
     { url = "https://files.pythonhosted.org/packages/34/e7/ae39f538fd6844e982063c3a5e4598b8ced43b9633baa3a85ef33af8c05c/pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8", size = 6984598, upload-time = "2025-07-01T09:16:27.732Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
 ]
 
 [[package]]
@@ -909,6 +968,45 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/0a/42348c995c67e2e6e5c89ffb9cfd68507cbaeb84ff39c49ee6e0a6dd0fd2/tokenizers-0.21.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c212aa4e45ec0bb5274b16b6f31dd3f1c41944025c2358faaa5782c754e84c24", size = 9461980, upload-time = "2025-07-28T15:48:52.325Z" },
     { url = "https://files.pythonhosted.org/packages/3d/d3/dacccd834404cd71b5c334882f3ba40331ad2120e69ded32cf5fda9a7436/tokenizers-0.21.4-cp39-abi3-win32.whl", hash = "sha256:6c42a930bc5f4c47f4ea775c91de47d27910881902b0f20e4990ebe045a415d0", size = 2329871, upload-time = "2025-07-28T15:48:56.841Z" },
     { url = "https://files.pythonhosted.org/packages/41/f2/fd673d979185f5dcbac4be7d09461cbb99751554ffb6718d0013af8604cb/tokenizers-0.21.4-cp39-abi3-win_amd64.whl", hash = "sha256:475d807a5c3eb72c59ad9b5fcdb254f6e17f53dfcbb9903233b0dfa9c943b597", size = 2507568, upload-time = "2025-07-28T15:48:55.456Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429, upload-time = "2024-11-27T22:37:56.698Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067, upload-time = "2024-11-27T22:37:57.63Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030, upload-time = "2024-11-27T22:37:59.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898, upload-time = "2024-11-27T22:38:00.429Z" },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894, upload-time = "2024-11-27T22:38:02.094Z" },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319, upload-time = "2024-11-27T22:38:03.206Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273, upload-time = "2024-11-27T22:38:04.217Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310, upload-time = "2024-11-27T22:38:05.908Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309, upload-time = "2024-11-27T22:38:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762, upload-time = "2024-11-27T22:38:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453, upload-time = "2024-11-27T22:38:09.384Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486, upload-time = "2024-11-27T22:38:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349, upload-time = "2024-11-27T22:38:11.443Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159, upload-time = "2024-11-27T22:38:13.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243, upload-time = "2024-11-27T22:38:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645, upload-time = "2024-11-27T22:38:15.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584, upload-time = "2024-11-27T22:38:17.645Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875, upload-time = "2024-11-27T22:38:19.159Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418, upload-time = "2024-11-27T22:38:20.064Z" },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708, upload-time = "2024-11-27T22:38:21.659Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582, upload-time = "2024-11-27T22:38:22.693Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543, upload-time = "2024-11-27T22:38:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691, upload-time = "2024-11-27T22:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170, upload-time = "2024-11-27T22:38:27.921Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530, upload-time = "2024-11-27T22:38:29.591Z" },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666, upload-time = "2024-11-27T22:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954, upload-time = "2024-11-27T22:38:31.702Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add pytest configuration to restrict collection to tests directory
- add comprehensive unit tests for utils, metrics, sampler policies, and data utilities
- include pytest as a project dependency to ensure torch-powered tests run

## Testing
- `uv run python -m papote.test_all`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689babb95d3c8332b6de7038e64bb261