### PR TITLE
Handle seq_dim in Rotary

### DIFF
--- a/papote/model.py
+++ b/papote/model.py
@@ -83,6 +83,18 @@ class Rotary(torch.nn.Module):
             self.sin_cached = emb.sin()
             self.seq_len_cached = seq_len
         cos, sin = self.cos_cached[:seq_len], self.sin_cached[:seq_len]
+
+        # reshape cos/sin for broadcasting on the sequence dimension
+        ndim = q.ndim
+        seq_dim = seq_dim % ndim
+        # default layout already matches (seq_len, dim)
+        if seq_dim != ndim - 2:
+            shape = [1] * ndim
+            shape[seq_dim] = seq_len
+            shape[-1] = cos.shape[-1]
+            cos = cos.reshape(shape)
+            sin = sin.reshape(shape)
+
         return self.apply_rotary_pos_emb(q, k, v, cos, sin)
 
     # rotary pos emb helpers:

--- a/tests/test_rotary.py
+++ b/tests/test_rotary.py
@@ -85,7 +85,6 @@ def test_forward_reuses_cache_for_shorter_sequence():
     assert torch.allclose(v_out, v2)
 
 
-@pytest.mark.xfail(reason="Rotary ignores seq_dim argument")
 def test_forward_seq_dim_argument():
     torch.manual_seed(3)
     rot = Rotary(4)


### PR DESCRIPTION
## Summary
- correctly broadcast rotary embeddings along arbitrary sequence dimensions
- skip rotary tensor reshaping when sequence axis is already in default position
- test rotary seq_dim argument without expected failure

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bb93f800c833282313c3e7546e520