### PR TITLE
Add server tests and checkpoint loader fix

### DIFF
--- a/papote/model.py
+++ b/papote/model.py
@@ -479,15 +479,15 @@ class Transformer(nn.Module):
 
 
 def transformer_from_checkpoint(checkpoint):
-    specs = list_models()[checkpoint['model_type']]
-    print('Loading model', checkpoint['model'].keys())
-    return make_transformer(
-        checkpoint['model_type'],
-        checkpoint['model']
-        ['_orig_mod.token_embedding.token_embedding.weight'].shape[0],
-        512  #checkpoint['model']['positional_embedding'].shape[1],
+    """Rebuild a :class:`Transformer` from a training checkpoint."""
+    state = checkpoint["model"]
+    token_emb_key = next(
+        k for k in state.keys()
+        if k.endswith("token_embedding.token_embedding.weight")
     )
-
+    vocab_size = state[token_emb_key].shape[0]
+    context_len = int(state.get("context_size", torch.tensor(512)))
+    return make_transformer(checkpoint["model_type"], vocab_size, context_len)
 
 def list_models():
     from model_specs.tiny import list_models as tiny

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,61 @@
+import torch
+
+from papote.server import build_sampler, Printer
+from papote.model import make_transformer, transformer_from_checkpoint
+from papote.bpe import BPE
+
+
+def test_checkpoint_roundtrip(tmp_path):
+    """Ensure checkpoints saved by training can be loaded by the server."""
+    bpe = BPE()
+    model = make_transformer("tiny-1M", vocab_size=8, context_len=16)
+    checkpoint = {
+        "model_type": "tiny-1M",
+        "model": model.state_dict(),
+        "bpe": bpe.state_dict(),
+    }
+
+    path = tmp_path / "ckpt.pt"
+    torch.save(checkpoint, path)
+
+    ckpt = torch.load(path)
+    bpe2 = BPE()
+    bpe2.load_state_dict(ckpt["bpe"])
+    model2 = transformer_from_checkpoint(ckpt)
+    load_res = model2.load_state_dict(ckpt["model"])
+    assert not load_res.missing_keys
+    assert not load_res.unexpected_keys
+
+
+def test_build_sampler_uses_printer():
+    """``build_sampler`` should attach a ``Printer`` event handler."""
+
+    class DummyBPE:
+        vocab = [b"a", b"b", b"c"]
+        specials = {}
+
+        def decode_text(self, ids, separator=""):
+            if isinstance(ids, int):
+                ids = [ids]
+            tokens = []
+            for i in ids:
+                if i < len(self.vocab):
+                    tokens.append(self.vocab[i].decode("utf-8"))
+                else:
+                    tokens.append(str(i))
+            return separator.join(tokens)
+
+    sent = []
+
+    def send(msg):
+        sent.append(msg)
+
+    model = make_transformer("tiny-1M", vocab_size=5, context_len=8)
+    bpe = DummyBPE()
+    sampler = build_sampler(model, bpe, send)
+
+    assert isinstance(sampler.event_handler, Printer)
+
+    sampler.event_handler([1, 2], 1, 0.5, 0.0)
+    assert sent, "send should be called by the printer"
+


### PR DESCRIPTION
## Summary
- fix `transformer_from_checkpoint` to rebuild models from saved checkpoints
- add server-focused tests including checkpoint round-trip and sampler printer

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c4f435ffc83328a0f3e069d0932b2