### PR TITLE
feat: add rotary toggles to Transformer

### DIFF
--- a/tests/test_transformer_rotary_flags.py
+++ b/tests/test_transformer_rotary_flags.py
@@ -50,3 +50,34 @@ def test_rotary_flags_checkpoint_roundtrip():
     loaded = transformer_from_checkpoint(ckpt)
     assert isinstance(loaded.transformer_blocks[0].sa.rotary, NoRotary)
     assert isinstance(loaded.rotary, nn.Identity)
+
+def _run_forward(rotary: bool, rotary_single: bool):
+    model = Transformer(
+        num_tokens=10,
+        hidden_size=8,
+        num_layers=1,
+        num_heads=2,
+        head_size=4,
+        context_size=8,
+        rotary=rotary,
+        rotary_single=rotary_single,
+    )
+    x = torch.randint(0, 10, (1, 8))
+    out = model(x)
+    assert out.shape == (1, 8, 10)
+
+
+def test_forward_rotary_both():
+    _run_forward(True, True)
+
+
+def test_forward_rotary_only_layers():
+    _run_forward(True, False)
+
+
+def test_forward_rotary_single_only():
+    _run_forward(False, True)
+
+
+def test_forward_no_rotary():
+    _run_forward(False, False)

--- a/tests/test_transformer_rotary_flags.py
+++ b/tests/test_transformer_rotary_flags.py
@@ -1,6 +1,13 @@
 import torch
 import torch.nn as nn
-from papote.model import Transformer, Rotary, RotarySingle, NoRotary
+from papote.model import (
+    Transformer,
+    Rotary,
+    RotarySingle,
+    NoRotary,
+    make_transformer,
+    transformer_from_checkpoint,
+)
 
 
 def test_transformer_rotary_flags():
@@ -29,3 +36,17 @@ def test_transformer_rotary_flags():
     )
     assert isinstance(model_no.transformer_blocks[0].sa.rotary, NoRotary)
     assert isinstance(model_no.rotary, nn.Identity)
+
+
+def test_rotary_flags_checkpoint_roundtrip():
+    model = make_transformer(
+        "tiny-1M",
+        vocab_size=10,
+        context_len=8,
+        rotary=False,
+        rotary_single=False,
+    )
+    ckpt = {"model_type": "tiny-1M", "model": model.state_dict()}
+    loaded = transformer_from_checkpoint(ckpt)
+    assert isinstance(loaded.transformer_blocks[0].sa.rotary, NoRotary)
+    assert isinstance(loaded.rotary, nn.Identity)

--- a/tests/test_transformer_rotary_flags.py
+++ b/tests/test_transformer_rotary_flags.py
@@ -1,0 +1,31 @@
+import torch
+import torch.nn as nn
+from papote.model import Transformer, Rotary, RotarySingle, NoRotary
+
+
+def test_transformer_rotary_flags():
+    model = Transformer(
+        num_tokens=10,
+        hidden_size=8,
+        num_layers=1,
+        num_heads=2,
+        head_size=4,
+        context_size=8,
+        rotary=True,
+        rotary_single=True,
+    )
+    assert isinstance(model.transformer_blocks[0].sa.rotary, Rotary)
+    assert isinstance(model.rotary, RotarySingle)
+
+    model_no = Transformer(
+        num_tokens=10,
+        hidden_size=8,
+        num_layers=1,
+        num_heads=2,
+        head_size=4,
+        context_size=8,
+        rotary=False,
+        rotary_single=False,
+    )
+    assert isinstance(model_no.transformer_blocks[0].sa.rotary, NoRotary)
+    assert isinstance(model_no.rotary, nn.Identity)


### PR DESCRIPTION
## Summary
- add `rotary` and `rotary_single` flags to Transformer and attention blocks
- add tests verifying rotary flags behavior

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c6b29241c833291b0551ec9851313