### PR TITLE
Share rotary embedding cache across instances

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,13 @@
 import sys
 from pathlib import Path
 
+import pytest
+from papote.model import Rotary, RotarySingle
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+@pytest.fixture(autouse=True)
+def clear_rotary_cache():
+    Rotary._cache.clear()
+    RotarySingle._cache.clear()


### PR DESCRIPTION
## Summary
- share cosine/sine rotary caches across instances to avoid duplication
- reset caches between tests and verify shared cache reuse

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c85acdc3883328e224bd54202fb3d