### PR TITLE
Add configurable permutation transform

### DIFF
--- a/papote/data_utils.py
+++ b/papote/data_utils.py
@@ -108,6 +108,22 @@ class Crop:
         return text
 
 
+class Permute:
+
+    def __init__(self, n, k):
+        self.permutations = [torch.arange(k)]
+        for _ in range(n - 1):
+            self.permutations.append(torch.randperm(k))
+
+    def __call__(self, x):
+        idx = random.randrange(len(self.permutations))
+        perm = self.permutations[idx]
+        if isinstance(x, torch.Tensor):
+            return idx, perm, x[perm]
+        else:
+            return idx, perm, [x[i] for i in perm.tolist()]
+
+
 class FillInTheMiddle:
 
     def __init__(self, suffix, prefix, wrap, p=0.5):

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -10,6 +10,7 @@ from papote.data_utils import (
     RandomPromptSplit,
     Tokenize,
     Crop,
+    Permute,
     NFKC,
     Pad,
     Align,
@@ -57,6 +58,23 @@ def test_nfkc_pad_align():
     assert pad([1, 2]) == [1, 2, 0, 0, 0]
     align = Align(4, 0)
     assert align([1, 2, 3, 4, 5]) == [1, 2, 3, 4, 5, 0, 0, 0]
+
+
+def test_permute():
+    p = Permute(3, 4)
+    assert len(p.permutations) == 3
+    assert torch.equal(p.permutations[0], torch.arange(4))
+    for perm in p.permutations:
+        assert torch.equal(torch.sort(perm).values, torch.arange(4))
+
+    random.seed(0)
+    expected_idx = random.randrange(3)
+    random.seed(0)
+    seq = torch.arange(4)
+    idx, perm, permuted = p(seq)
+    assert idx == expected_idx
+    assert torch.equal(perm, p.permutations[idx])
+    assert torch.equal(permuted, seq[perm])
 
 
 def test_tagger():


### PR DESCRIPTION
## Summary
- add `Permute` transform generating a set of stored permutations and applying one at random
- cover `Permute` behavior with unit tests

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d07d7d4448332b4f9cb72b583efa5